### PR TITLE
Reserve missions

### DIFF
--- a/src/components/Header.scss
+++ b/src/components/Header.scss
@@ -5,6 +5,12 @@ header {
   padding: 3rem;
   margin: 0 3rem 5rem 3rem;
   border-bottom: 1px solid grey;
+  top: 0;
+  left: 0;
+  right: 0;
+  position: sticky;
+  background-color: #fff;
+  z-index: 2;
 
   .logo {
     display: flex;

--- a/src/components/MissionItem.js
+++ b/src/components/MissionItem.js
@@ -1,17 +1,51 @@
 import { PropTypes } from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission, leaveMission } from '../redux/missions/missions';
 import './Mission.scss';
 
 const MissionItem = (props) => {
+  const dispatch = useDispatch();
   const {
-    id, name, description,
+    id, name, description, reserved,
   } = props;
+
+  const handleJoinMission = () => {
+    dispatch(joinMission(id));
+  };
+
+  const handleLeaveMission = () => {
+    dispatch(leaveMission(id));
+  };
+
   return (
     <tr id={id}>
       <td className="td-name">{name}</td>
       <td className="td-description">{description}</td>
-      <td className="td-badge"><span>NOT A MEMBER</span></td>
+      <td className="td-badge">
+        {reserved ? (
+          <span className="active-member">Active Member</span>
+        ) : (
+          <span>NOT A MEMBER</span>
+        )}
+      </td>
       <td className="td-button">
-        <button type="button">Join Mission</button>
+        {reserved ? (
+          <button
+            type="button"
+            className="remove-reservation red"
+            onClick={handleLeaveMission}
+          >
+            Leave Mission
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="add-reservation"
+            onClick={handleJoinMission}
+          >
+            Join Mission
+          </button>
+        )}
       </td>
     </tr>
   );
@@ -21,6 +55,7 @@ MissionItem.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  reserved: PropTypes.bool.isRequired,
 };
 
 export default MissionItem;

--- a/src/components/MissionItem.scss
+++ b/src/components/MissionItem.scss
@@ -3,6 +3,7 @@ table {
   width: 90%;
   border-collapse: collapse;
   border: 2px solid #ddd;
+  margin-bottom: 4rem;
 
   th {
     font-weight: bold;
@@ -37,9 +38,13 @@ table {
     font-size: 1rem;
     font-weight: bold;
     color: white;
-    border-radius: 8px;
-    padding: 1rem;
+    border-radius: 6px;
+    padding: 0.4rem 1rem;
     background-color: grey;
+  }
+
+  .active-member {
+    background-color: #18a2b8;
   }
 
   .td-button {

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,14 +1,17 @@
-// import { useSelector, useDispatch } from 'react-redux';
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import MissionItem from './MissionItem';
-// import { fetchMissionsFromAPI } from '../redux/missions/missions';
+import { fetchMissionsFromAPI } from '../redux/missions/missions';
 import './MissionItem.scss';
 
 const Missions = () => {
-  // const dispatch = useDispatch();
   const missionList = useSelector((state) => state.missionsReducer);
 
-  // dispatch(fetchMissionsFromAPI());
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (missionList.length === 0) dispatch(fetchMissionsFromAPI());
+  });
 
   return (
     <section className="missions-container">
@@ -29,6 +32,7 @@ const Missions = () => {
                 id={mission.id}
                 name={mission.name}
                 description={mission.description}
+                reserved={mission.reserved}
               />
             ))
           }

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,15 +1,34 @@
 import { useSelector } from 'react-redux';
 import ReservedRocket from './ReservedRocket';
+import ReservedMission from './ReservedMissions';
 import './Profile.scss';
 
 const Profile = () => {
   const rocketList = useSelector((state) => state.rocketsReducer);
   const reservedRockets = rocketList.filter((rocket) => rocket.reserved === true);
-  console.log(reservedRockets);
+  const missionList = useSelector((state) => state.missionsReducer);
+  const reservedMissions = missionList.filter((mission) => mission.reserved === true);
   return (
-    <>
+    <div className="profile-container">
+      {reservedMissions.length ? (
+        <div className="reserved__section">
+          <h2>My Missions</h2>
+          <ul>
+            {reservedMissions.map((item) => (
+              <ReservedMission
+                key={item.id}
+                id={item.id}
+                name={item.name}
+                wikipedia={item.wikipedia}
+              />
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <h2 className="empty empty-missions">No missions have been joined yet</h2>
+      )}
       {reservedRockets.length ? (
-        <div className="reserved-rockets__section">
+        <div className="reserved__section left">
           <h2>My Rockets</h2>
           <ul>
             {reservedRockets.map((item) => (
@@ -25,7 +44,7 @@ const Profile = () => {
       ) : (
         <h2 className="empty">No Rockets have been reserved yet</h2>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/Profile.scss
+++ b/src/components/Profile.scss
@@ -63,20 +63,25 @@
 
   h2 {
     font-size: 2.8rem;
+    margin-bottom: 2rem;
   }
 
   ul {
     display: flex;
     flex-direction: column;
+    background-color: white;
+    overflow: hidden;
+    border: 1px solid gray;
+    border-radius: 15px;
 
     .reserved__container {
       display: flex;
       padding: 2rem;
-      border: 1px solid gray;
-      border-top: none;
+      border-bottom: 1px solid gray;
+      background-image: linear-gradient(to right, rgba(128, 128, 128, 0.541), white);
 
-      &:first-child {
-        border-top: 1px solid gray;
+      &:last-child {
+        border-bottom: none;
       }
 
       h3 {
@@ -137,7 +142,6 @@
             color: blueviolet;
             box-shadow: inset 0 0 5px blueviolet;
           }
-
         }
       }
     }
@@ -147,7 +151,7 @@
 .red {
   border: 1px solid red !important;
   color: red !important;
-  
+
   &:hover {
     color: blueviolet !important;
     border-color: blueviolet !important;
@@ -157,7 +161,6 @@
     color: blueviolet !important;
     box-shadow: inset 0 0 5px blueviolet !important;
   }
-
 }
 
 // .right {
@@ -168,5 +171,4 @@
   margin-left: auto;
   float: right;
   padding: 0 6rem 6rem 2rem;
-
 }

--- a/src/components/Profile.scss
+++ b/src/components/Profile.scss
@@ -6,7 +6,7 @@
   background-color: white;
   box-shadow: 0 0 5px orange;
   top: 40%;
-  left: 33%;
+  right: 10%;
   border: 1px solid;
   display: flex;
   justify-content: center;
@@ -15,22 +15,50 @@
   animation: slideIn infinite 8s linear;
 
   @keyframes slideIn {
-    from {
-      left: -30%;
+    0% {
+      top: 50%;
     }
 
-    to {
-      left: 130%;
+    50% {
+      top: 40%;
+    }
+
+    100% {
+      top: 50%;
     }
   }
 }
 
-.reserved-rockets__section {
+.empty-missions {
+  position: absolute;
+  left: 10%;
+  animation: missions-slideIn infinite 8s linear;
+
+  @keyframes missions-slideIn {
+    0% {
+      top: 50%;
+    }
+
+    50% {
+      top: 40%;
+    }
+
+    100% {
+      top: 50%;
+    }
+  }
+}
+
+.profile-container {
+  display: flex;
+  position: relative;
+  min-height: 50vh;
+}
+
+.reserved__section {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  margin-left: auto;
-  padding: 0 6rem 6rem 2rem;
+  padding: 0 2rem 6rem 6rem;
   width: 50%;
 
   h2 {
@@ -41,7 +69,7 @@
     display: flex;
     flex-direction: column;
 
-    .reserved-rocket__container {
+    .reserved__container {
       display: flex;
       padding: 2rem;
       border: 1px solid gray;
@@ -56,7 +84,7 @@
         align-self: center;
       }
 
-      .reserved-rocket__buttons {
+      .reserved__buttons {
         display: flex;
         align-items: center;
         margin-left: auto;
@@ -109,8 +137,36 @@
             color: blueviolet;
             box-shadow: inset 0 0 5px blueviolet;
           }
+
         }
       }
     }
   }
+}
+
+.red {
+  border: 1px solid red !important;
+  color: red !important;
+  
+  &:hover {
+    color: blueviolet !important;
+    border-color: blueviolet !important;
+  }
+
+  &:active {
+    color: blueviolet !important;
+    box-shadow: inset 0 0 5px blueviolet !important;
+  }
+
+}
+
+// .right {
+//   margin-left: auto;
+// }
+
+.left {
+  margin-left: auto;
+  float: right;
+  padding: 0 6rem 6rem 2rem;
+
 }

--- a/src/components/ReservedMissions.js
+++ b/src/components/ReservedMissions.js
@@ -1,0 +1,34 @@
+import { useDispatch } from 'react-redux';
+import { PropTypes } from 'prop-types';
+import { leaveMission } from '../redux/missions/missions';
+
+const ReservedMission = (props) => {
+  const dispatch = useDispatch();
+  const { id, name, wikipedia } = props;
+
+  const handleLeaveMission = () => {
+    dispatch(leaveMission(id));
+  };
+
+  console.log(wikipedia, 'este');
+
+  return (
+    <li className="reserved__container" id={id}>
+      <h3>{name}</h3>
+      <div className="reserved__buttons">
+        <a href={wikipedia} target="_blank" rel="noreferrer">Read more</a>
+        <button type="button" className="remove-reservation" onClick={handleLeaveMission}>
+          Leave Mission
+        </button>
+      </div>
+    </li>
+  );
+};
+
+ReservedMission.propTypes = {
+  name: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  wikipedia: PropTypes.string.isRequired,
+};
+
+export default ReservedMission;

--- a/src/components/ReservedRocket.js
+++ b/src/components/ReservedRocket.js
@@ -11,10 +11,10 @@ const ReservedRocket = (props) => {
   };
 
   return (
-    <li className="reserved-rocket__container" id={id}>
+    <li className="reserved__container" id={id}>
       <h3>{name}</h3>
-      <div className="reserved-rocket__buttons">
-        <a href={wikipedia}>Read more</a>
+      <div className="reserved__buttons">
+        <a href={wikipedia} target="_blank" rel="noreferrer">Read more</a>
         <button type="button" className="remove-reservation" onClick={handleCancelReservation}>
           Cancel Reservation
         </button>

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -2,16 +2,14 @@ import { createStore, combineReducers, applyMiddleware } from 'redux';
 import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 import rocketsReducer, { getRocketsFromAPI } from './rockets/rockets';
-import missionsReducer, { fetchMissionsFromAPI } from './missions/missions';
+import missionsReducer from './missions/missions';
 
 const reducer = combineReducers({
   missionsReducer,
   rocketsReducer,
-  // additional reducers could be added here
 });
 
 const store = createStore(reducer, applyMiddleware(thunk, logger));
 store.dispatch(getRocketsFromAPI());
-store.dispatch(fetchMissionsFromAPI());
 
 export default store;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -8,14 +8,14 @@ const baseURL = 'https://api.spacexdata.com/v3/missions';
 const initialState = [];
 
 // action creators
-export const joinMission = (payload) => ({
+export const joinMission = (id) => ({
   type: JOIN_MISSION,
-  payload,
+  id,
 });
 
-export const leaveMission = (payload) => ({
+export const leaveMission = (id) => ({
   type: LEAVE_MISSION,
-  payload,
+  id,
 });
 
 export const fetchMissions = (payload) => ({
@@ -28,11 +28,11 @@ export const fetchMissionsFromAPI = () => async (dispatch) => {
   await fetch(`${baseURL}`)
     .then((response) => response.json())
     .then((MissionsList) => {
-      console.log(MissionsList);
       const arrangedList = MissionsList.map((mission) => ({
         id: mission.mission_id,
         name: mission.mission_name,
         description: mission.description,
+        wikipedia: mission.wikipedia,
         reserved: false,
       }));
       if (arrangedList) {
@@ -44,10 +44,20 @@ export const fetchMissionsFromAPI = () => async (dispatch) => {
 // reducer
 const missionsReducer = (state = initialState, action) => {
   switch (action.type) {
-    case JOIN_MISSION:
-      return [...state, action.payload];
-    case LEAVE_MISSION:
-      return state.filter((mission) => mission.item_id !== action.payload);
+    case JOIN_MISSION: {
+      const newState = state.map((mission) => {
+        if (mission.id !== action.id) return mission;
+        return { ...mission, reserved: true };
+      });
+      return [...newState];
+    }
+    case LEAVE_MISSION: {
+      const newState = state.map((mission) => {
+        if (mission.id !== action.id) return mission;
+        return { ...mission, reserved: false };
+      });
+      return [...newState];
+    }
     case FETCH_MISSIONS:
       return [...action.payload];
     default:


### PR DESCRIPTION
## Hi @zhadier :wave: 

In this pull request I:
- Added dispatch for user click on the "Join Mission" button to update the store using id. - Returned a new state object with all missions, but the selected mission will have a reserved state with its value set to true.
- Followed the same logic as with the "Join Mission", but set the reserved key to false when leaving mission.
- Missions that have already been joined show a "Active Member" badge and "Leave Mission" button instead of the default "Join Mission". 
- Add a filtered list of reserved missions in profile component Added styling to the profile section Added Leave Mission and Read more feature buttons Added animation when profile section has 0 reserved items Changed thunk function to get data about Wikipedia from API.

---
Any comment or suggestion will be thankfully received :+1:
